### PR TITLE
send different certificate if acme-tls/1 negotated with alpn

### DIFF
--- a/txsni/parser.py
+++ b/txsni/parser.py
@@ -22,7 +22,9 @@ class SNIDirectoryParser(object):
             return ':'.join([item.replace(':', '\\:') for item in items])
         sub = colonJoin(list(args) + ['='.join(item) for item in kw.items()])
         subEndpoint = serverFromString(reactor, sub)
-        contextFactory = SNIMap(HostDirectoryMap(FilePath(expanduser(pemdir))))
+        mapping = HostDirectoryMap(FilePath(expanduser(pemdir)))
+        acme_mapping = HostDirectoryMap(FilePath(expanduser(pemdir + '/acme')))
+        contextFactory = SNIMap(mapping, acme_mapping)
         return TLSEndpoint(endpoint=subEndpoint,
                            contextFactory=contextFactory)
 


### PR DESCRIPTION
As you probably know letsencrypt requires alpn negotiation instead of just SNI these days.

This change intercepts alpn negotiation so that acme-tls/1 is always used if the client supports it. Then txsni chooses certificates from a second mapping, currently just an alpn/ directory underneath the default mapping, to use for that connection. When letsencrypt sees that special cert it knows you control the domain.

So if you have already generated the special certificate and placed it in acme/hostname.pem, txsni will be able to make letsencrypt happy. Then your ACME client can finish issuing you a new cert.

I expect to use this with dehydrated, the shell script acme client, and possibly with a new mapping object that can do dehydrated's separate key / cert layout. There's not enough here for txsni's "even the first request succeeds after waiting for the new certificate" but it should be really handy for development.